### PR TITLE
Add AmazonS3Fetcher, HcpDataset

### DIFF
--- a/nidata/datasets/__init__.py
+++ b/nidata/datasets/__init__.py
@@ -1,0 +1,3 @@
+class Dataset(object):
+    def fetch(self, n_subjects=1, force=True, check=False, verbosity=1):
+        raise NotImplementedError()

--- a/nidata/fetchers/aws_fetcher.py
+++ b/nidata/fetchers/aws_fetcher.py
@@ -6,41 +6,77 @@ import time
 import warnings
 from functools import partial
 
-import boto
+import nibabel as nib
 import numpy as np
 
-from . import _chunk_report_
+from .base import _chunk_report_, Fetcher
 
 
 def test_cb(cur_bytes, total_bytes, t0=None, **kwargs):
     return _chunk_report_(bytes_so_far=cur_bytes, total_size=total_bytes, initial_size=0, t0=t0)
 
 
-def aws_fetcher(data_dir, files, access_key=None, secret_access_key=None, profile_name=None, force=True):
-    if profile_name is not None:
-        s3 = boto.connect_s3(profile_name=profile_name)
-    elif access_key is not None and secret_access_key is not None:
-        s3 = boto.connect_s3(access_key, secret_access_key)
+class AmazonS3Fetcher(Fetcher):
+    dependencies = ['boto']
 
+    def __init__(self, data_dir=None, access_key=None, secret_access_key=None, profile_name=None):
+        if not (profile_name or (access_key and secret_access_key)):
+            raise ValueError('profile_name or access_key / secret_access_key must be provided.')
+        super(AmazonS3Fetcher, self).__init__(data_dir=data_dir)
+        self.access_key = access_key
+        self.secret_access_key = secret_access_key
+        self.profile_name = profile_name
 
-    bucket_names = np.unique([opts.get('bucket') for f, rk, opts in files])
-    for bucket_name in bucket_names:  # loop over bucket names for efficiency.
-        if bucket_name:
-            buck = s3.get_bucket(bucket_name)
-        else:
-            buck = s3.get_all_buckets()[0]
+    def fetch(self, files, force=False, check=False, verbosity=1):
+        assert self.profile_name or (self.access_key and self.secret_access_key)
 
+        files = Fetcher.reformat_files(files)  # allows flexibility
+        import boto
+        if self.profile_name is not None:
+            s3 = boto.connect_s3(profile_name=self.profile_name)
+        elif self.access_key is not None and self.secret_access_key is not None:
+            s3 = boto.connect_s3(self.access_key, self.secret_access_key)
+
+        bucket_names = np.unique([opts.get('bucket') for f, rk, opts in files])
         files_ = []
-        for file_, remote_key, opts in files:
-            if opts.get('bucket') != bucket_name:
-                continue
-            target_file = os.path.join(data_dir, file_)
-            key = buck.get_key(remote_key)
-            if not key:
-                warnings.warn('Failed to find key: %s' % remote_key)
-                files_.append(None)
-            elif force or not os.path.exists(target_file):
-                with open(target_file, 'wb') as fp:
-                    key.get_contents_to_file(fp, cb=partial(test_cb, t0=time.time()), num_cb=None)
-                files_.append(target_file)
-    return files_
+        for bucket_name in bucket_names:  # loop over bucket names: efficient
+            if bucket_name:  # bucket requested
+                buck = s3.get_bucket(bucket_name)
+            else:  # default to first bucket
+                buck = s3.get_all_buckets()[0]
+
+            for file_, remote_key, opts in files:
+                if opts.get('bucket') != bucket_name:
+                    continue  # get all files from the current bucket only.
+                target_file = os.path.join(self.data_dir, file_)
+                key = buck.get_key(remote_key)
+                if not key:
+                    warnings.warn('Failed to find key: %s' % remote_key)
+                    files_.append(None)
+                else:
+                    do_download = force or not os.path.exists(target_file)
+                    try:
+                        do_download = do_download or (check and nib.load(target_file).get_data() is not None)
+                    except IOError as ioe:
+                        if verbosity > 0:
+                            print("Warning: %s corrupted, re-downloading (Error=%s)" % (target_file, ioe))
+                        do_download = True
+
+                    if do_download:
+                        # Ensure destination directory exists
+                        destination_dir = os.path.dirname(target_file)
+                        if not os.path.isdir(destination_dir):
+                            if verbosity > 0:
+                                print("Creating base directory %s" % destination_dir)
+                            os.mkdir(destination_dir)
+
+                        if verbosity > 0:
+                            print("Downloading [%s]/%s to %s." % (
+                                bucket_name or 'default bucket',
+                                remote_key,
+                                target_file))
+                        with open(target_file, 'wb') as fp:
+                            key.get_contents_to_file(fp, cb=partial(test_cb, t0=time.time()), num_cb=None)
+
+                    files_.append(target_file)
+        return files_

--- a/nidata/multimodal/__init__.py
+++ b/nidata/multimodal/__init__.py
@@ -1,0 +1,3 @@
+"""
+"""
+from .hcp import HcpDataset

--- a/nidata/multimodal/hcp.py
+++ b/nidata/multimodal/hcp.py
@@ -1,0 +1,39 @@
+from ..fetchers import AmazonS3Fetcher
+from ..datasets import Dataset
+
+
+class HcpDataset(Dataset):
+    def __init__(self, fetcher_type='aws', profile_name=None, access_key=None, secret_access_key=None):
+        """fetcher_type: aws or XNAT"""
+        if fetcher_type == 'aws':
+            self.fetcher = AmazonS3Fetcher(profile_name=profile_name,
+                                           access_key=access_key,
+                                           secret_access_key=secret_access_key)
+        else:
+            raise NotImplementedError(fetcher_type)
+
+    def get_subject_list(self, n_subjects=500):
+        """Get the list of subject IDs. Depends on the # of subjects,
+        which also corresponds to other things (license agreement,
+        type of data available, etc)"""
+        return ['992774']
+
+    def fetch(self, n_subjects=1, data_types=None, force=False, check=True, verbosity=1):
+        """data_types is a list, can contain: anat, diff, func, rest, psyc, bgnd
+        """
+        subj_ids = self.get_subject_list(n_subjects=n_subjects)
+
+        # Build a list of files to fetch
+        files = []
+        for subj_id in subj_ids[:n_subjects]:
+            for dtype in (data_types or ['anat', 'diff', 'func', 'rest']):
+                if dtype == 'diff':
+                    files += zip(['hcp/dwi_lr.nii.gz', 'hcp/dwi_lr.bval', 'hcp/dwi_lr.bvec'],
+                                 ['HCP/%(subj_id)s/unprocessed/3T/Diffusion/%(subj_id)s_3T_DWI_dir95_LR.nii.gz' % {'subj_id': subj_id},
+                                  'HCP/%(subj_id)s/unprocessed/3T/Diffusion/%(subj_id)s_3T_DWI_dir95_LR.bval'   % {'subj_id': subj_id},
+                                  'HCP/%(subj_id)s/unprocessed/3T/Diffusion/%(subj_id)s_3T_DWI_dir95_LR.bvec'   % {'subj_id': subj_id}],
+                                 [{}, {}, {}])
+                else:
+                    raise NotImplementedError()
+
+        return self.fetcher.fetch(files, force=force, check=check, verbosity=verbosity)


### PR DESCRIPTION
New object structure:
- `Fetchers` - encapsulate how to get data with a given protocol (s3, http, XNAT, etc) and website (Amazon, OpenFMRI, CRCNS, etc).
- `Datasets` - encapsulate individual research studies, with a simple function interface for fetching data on a per-subject basis. Returns a standardized output format.

This PR creates and `AmazonS3Fetcher`, and uses it to fetch `HCP` data. Currently, only implemented a bit of diffusion fetching as a proof of concept.

Example usage:

``` python
from nidata.multimodal import HcpDataset
print HcpDataset(profile_name='hcp').fetch(n_subjects=1, data_types=['diff'])
```

@arokem , this is a sloppy attempt to push your IPython notebook into an object wrapper.
