### PR TITLE
Add NeuroVault fetcher

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -10,3 +10,4 @@ omit =
     nidata/*/*/tests.py
     nidata/core/_utils/niimg.py
     nidata/core/_utils/numpy_conversions.py
+    nidata/core/fetchers/http_fetcher.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,6 @@ python:
   - "2.7"
   - "3.5"
 
-addons:
-  apt:
-    packages:
-    - libblas-dev  # scipy
-    - liblapack-dev  # scipy
-    - gfortran  # scipy
-    - libhdf5-dev  # hdf5
-    - libhdf5-serial-dev  # hdf5
-
 cache:
   - apt
   - directories:
@@ -23,12 +14,20 @@ notifications:
   email: false
 
 before_install:
-  - pip install -U pip
+  # Setup anaconda
+  - pip install -U --upgrade pip
+  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - chmod +x miniconda.sh
+  - ./miniconda.sh -b
+  - export PATH=$PATH:$HOME/miniconda2/bin
+  - export PYTHONPATH=$HOME/miniconda2/lib/python$TRAVIS_PYTHON_VERSION/site-packages/
+  - conda update --yes conda
 
 install: # Install packages
-  - pip install numpy virtualenv
-  - pip install nose setuptools pep8 pyflakes coverage
-  - pip install python-coveralls nose-cov
+  - echo $PATH
+  - echo $PYTHONPATH
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION numpy h5py scipy virtualenv
+  - pip install nose setuptools pep8 pyflakes coverage python-coveralls nose-cov
   - pip install profilehooks
   - python setup.py install
 

--- a/nidata/anatomical/oasis_vbm/__init__.py
+++ b/nidata/anatomical/oasis_vbm/__init__.py
@@ -7,6 +7,7 @@ from ...core.datasets import NilearnDataset
 
 class OasisVbmDataset(NilearnDataset):
     fetcher_function = 'nilearn.datasets.fetch_oasis_vbm'
+    nilearn_name = 'oasis1'
 
     def fetch(self, n_subjects=None, dartel_version=True,
               url=None, resume=True, force=False, verbose=1):

--- a/nidata/anatomical/oasis_vbm/__init__.py
+++ b/nidata/anatomical/oasis_vbm/__init__.py
@@ -10,8 +10,7 @@ class OasisVbmDataset(NilearnDataset):
 
     def fetch(self, n_subjects=None, dartel_version=True,
               url=None, resume=True, force=False, verbose=1):
-        super(OasisVbmDataset, self).fetch(data_dir=self.data_dir,
-                                           n_subjects=n_subjects,
+        super(OasisVbmDataset, self).fetch(n_subjects=n_subjects,
                                            dartel_version=dartel_version,
                                            url=url, resume=resume,
                                            verbose=verbose)

--- a/nidata/anatomical/oasis_vbm/tests.py
+++ b/nidata/anatomical/oasis_vbm/tests.py
@@ -1,4 +1,6 @@
+from nose.tools import assert_true
 from unittest import TestCase
+
 from nidata.anatomical import OasisVbmDataset
 from nidata.core._utils.testing import DownloadTestMixin, InstallTestMixin
 
@@ -9,3 +11,8 @@ class OasisVbmDownloadTest(DownloadTestMixin, TestCase):
 
 class OasisVbmInstallTest(InstallTestMixin, TestCase):
     dataset_class = OasisVbmDataset
+
+    def test_doc(self):
+        # doc should exist after instance creation.
+        OasisVbmDataset()
+        assert_true(len(OasisVbmDataset.__doc__) > 100)

--- a/nidata/atlas/haxby_etal_2011/tests.py
+++ b/nidata/atlas/haxby_etal_2011/tests.py
@@ -7,11 +7,11 @@ from nidata.atlas import HaxbyEtal2011Dataset
 from nidata.core._utils.testing import DownloadTestMixin, InstallTestMixin
 
 
-@unittest.skipIf(sys.version_info[0] > 1, "pymvpa does not support Python 3")
+@unittest.skipIf(sys.version_info[0] > 2, "pymvpa does not support Python 3")
 class HaxbyEtal2011DownloadTest(DownloadTestMixin, TestCase):
     dataset_class = HaxbyEtal2011Dataset
 
 
-@unittest.skipIf(sys.version_info[0] > 1, "pymvpa does not support Python 3")
+@unittest.skipIf(sys.version_info[0] > 2, "pymvpa does not support Python 3")
 class HaxbyEtal2011InstallTest(InstallTestMixin, TestCase):
     dataset_class = HaxbyEtal2011Dataset

--- a/nidata/core/datasets/__init__.py
+++ b/nidata/core/datasets/__init__.py
@@ -115,8 +115,7 @@ class Dataset(ClassWithDependencies):
     @classmethod
     def get_dataset_descr_path(cls):
         class_path = op.dirname(inspect.getfile(cls))
-        name = op.dirname(class_path)
-
+        name = op.basename(class_path)
         return op.join(class_path, name + '.rst')
 
     @classmethod
@@ -130,12 +129,17 @@ class Dataset(ClassWithDependencies):
             return ''
 
     def __init__(self, data_dir=None):
+        super(Dataset, self).__init__()
         class_path = op.dirname(inspect.getfile(self.__class__))
         self.name = op.basename(class_path)
         self.modality = op.basename(op.dirname(class_path))  # assume
         self.description = self.get_dataset_descr()
         self.data_dir = get_dataset_dir(self.name, data_dir=data_dir)
         self.fetcher = getattr(self, 'fetcher', None)  # set to *something*.
+
+        # Feeling lazy... handle this here, for now.
+        if self.__class__.__doc__ is None:
+            self.__class__.__doc__ = self.description
 
     def clean_data_directory(self):
         """ Function that guarantees a data directory."""
@@ -186,7 +190,9 @@ class NilearnDataset(FetcherFunctionDataset):
         import nilearn.datasets.description as descr
         class_path = op.dirname(inspect.getfile(cls))
         name = getattr(cls, 'nilearn_name', op.basename(class_path))
-        return op.join(op.dirname(descr.__file__), '%s.rst' % name)
+        descr_path = op.dirname(descr.__file__)
+        cls.rst_path = op.join(descr_path, '%s.rst' % name)
+        return cls.rst_path
 
 
 class NistatsDataset(FetcherFunctionDataset):

--- a/nidata/core/fetchers/__init__.py
+++ b/nidata/core/fetchers/__init__.py
@@ -1,6 +1,5 @@
 from .aws_fetcher import AmazonS3Fetcher
 from .http_fetcher import HttpFetcher
-from .base import Fetcher, FetcherFunctionFetcher
+from .base import Fetcher
 
-__all__ = ['AmazonS3Fetcher', 'HttpFetcher', 'Fetcher',
-           'FetcherFunctionFetcher']
+__all__ = ['AmazonS3Fetcher', 'HttpFetcher', 'Fetcher']

--- a/nidata/core/fetchers/base.py
+++ b/nidata/core/fetchers/base.py
@@ -7,7 +7,6 @@ Utilities to download NeuroImaging datasets
 
 import collections
 import hashlib
-import importlib
 import os
 import os.path as op
 import sys
@@ -212,23 +211,3 @@ class Fetcher(ClassWithDependencies):
 
     def fetch(self, files, force=False, check=False, verbose=1):
         raise NotImplementedError()
-
-
-class FetcherFunctionFetcher(Fetcher):
-
-    def __init__(self, fetcher_function, dependencies=(), data_dir=None,
-                 verbose=1):
-        super(FetcherFunctionFetcher, self).__init__(
-            data_dir=data_dir, verbose=verbose)
-
-        self.install_missing_dependencies(dependencies)
-
-        mod_path = '.'.join(fetcher_function.split('.')[:-1])
-        mod = importlib.import_module(mod_path)
-        func_name = fetcher_function.split('.')[-1]
-        func = getattr(mod, func_name)
-        self.__doc__ = func.__doc__
-        self._func = func
-
-    def fetch(self, *args, **kwargs):
-        return self._func(*args, **kwargs)

--- a/nidata/core/objdep.py
+++ b/nidata/core/objdep.py
@@ -18,6 +18,7 @@ def install_dependency(module_name, install_info=None, verify=False):
 
     # Install it.
     try:
+        print("Installing %s from %s..." % (module_name, install_info))
         rv = pip.main(['install', install_info])
         if rv != 0:
             warnings.warn('Pip returned %d' % rv)
@@ -62,14 +63,6 @@ class DependenciesMeta(type):
             def wrapper_fn(self, *args, **kwargs):
                 self.__class__.install_missing_dependencies()
                 return init_fn(self, *args, **kwargs)
-            return wrapper_fn
-
-        def super_init(cls):
-            """
-            TODO: super_init docstring
-            """
-            def wrapper_fn(self, *args, **kwargs):
-                return super(cls, self).__init__(*args, **kwargs)
             return wrapper_fn
 
         new_cls = super(DependenciesMeta, cls) \

--- a/nidata/localizer/brainomics/__init__.py
+++ b/nidata/localizer/brainomics/__init__.py
@@ -7,6 +7,7 @@ from ...core.datasets import NilearnDataset
 
 class BrainomicsDataset(NilearnDataset):
     fetcher_function = 'nilearn.datasets.fetch_localizer_contrasts'
+    nilearn_name = 'brainomics_localizer'
 
 
 def fetch_localizer_calculation_task(n_subjects=None, data_dir=None, url=None,

--- a/nidata/multimodal/my_connectome_2015/__init__.py
+++ b/nidata/multimodal/my_connectome_2015/__init__.py
@@ -75,8 +75,8 @@ class MyConnectome2015Dataset(HttpDataset):
                     files += [(uncompressed_dir, remote_url, opts)]
 
         # Now, fetch the files.
-        self.fetcher.fetch(files, resume=resume, force=force, verbose=verbose,
-                           delete_archive=False)
+        self.fetcher.fetch(files=files, resume=resume, force=force,
+                           verbose=verbose, delete_archive=False)
 
         # Group the data according to modality.
         out_dict = defaultdict(lambda: [])

--- a/nidata/resting_state/nyu/__init__.py
+++ b/nidata/resting_state/nyu/__init__.py
@@ -7,6 +7,7 @@ from ...core.datasets import NilearnDataset
 
 class NyuRestDataset(NilearnDataset):
     fetcher_function = 'nilearn.datasets.fetch_nyu_rest'
+    nilearn_name = 'nyu_rest'
 
 
 def fetch_nyu_rest(n_subjects=None, sessions=[1], data_dir=None, resume=True,

--- a/nidata/task/__init__.py
+++ b/nidata/task/__init__.py
@@ -3,7 +3,8 @@ Task-based functional MRI datasets
 """
 from .haxby_etal_2001 import Haxby2001Dataset
 from .miyawaki_2008 import Miyawaki2008Dataset
+from .neurovault import NeuroVaultDataset
 from .poldrack_etal_2001 import PoldrackEtal2001Dataset
 
 __all__ = ['Haxby2001Dataset', 'Miyawaki2008Dataset',
-           'PoldrackEtal2001Dataset']
+           'PoldrackEtal2001Dataset', 'NeuroVaultDataset']

--- a/nidata/task/haxby_etal_2001/__init__.py
+++ b/nidata/task/haxby_etal_2001/__init__.py
@@ -8,7 +8,7 @@ from ...core.datasets import NilearnDataset
 
 class Haxby2001Dataset(NilearnDataset):
     fetcher_function = 'nilearn.datasets.fetch_haxby'
-    nilearn_name = 'haxby_2001'
+    nilearn_name = 'haxby2001'
 
 
 def fetch_haxby_simple(data_dir=None, url=None, resume=True, verbose=1):

--- a/nidata/task/haxby_etal_2001/__init__.py
+++ b/nidata/task/haxby_etal_2001/__init__.py
@@ -8,6 +8,7 @@ from ...core.datasets import NilearnDataset
 
 class Haxby2001Dataset(NilearnDataset):
     fetcher_function = 'nilearn.datasets.fetch_haxby'
+    nilearn_name = 'haxby_2001'
 
 
 def fetch_haxby_simple(data_dir=None, url=None, resume=True, verbose=1):

--- a/nidata/task/neurovault/__init__.py
+++ b/nidata/task/neurovault/__init__.py
@@ -13,7 +13,7 @@ class NeuroVaultDataset(NilearnDataset):
     dependencies = OrderedDict(
         [(mod, mod) for mod in NilearnDataset.dependencies],
         nilearn=('git+git://github.com/bcipolli/'
-                 'nilearn@neurovault-downloader#egg=nilearn'))
+                 'nilearn@neurovault-downloader#egg=nilearn'))  # override
     fetcher_function = 'nilearn.datasets.fetch_neurovault'
 
 

--- a/nidata/task/neurovault/__init__.py
+++ b/nidata/task/neurovault/__init__.py
@@ -1,0 +1,38 @@
+# *- encoding: utf-8 -*-
+# Author: Ben Cipollini
+# License: simplified BSD
+
+from collections import OrderedDict
+
+import numpy as np
+
+from ...core.datasets import NilearnDataset
+
+
+class NeuroVaultDataset(NilearnDataset):
+    dependencies = OrderedDict(
+        [(mod, mod) for mod in NilearnDataset.dependencies],
+        nilearn=('git+git://github.com/bcipolli/'
+                 'nilearn@neurovault-downloader#egg=nilearn'))
+    fetcher_function = 'nilearn.datasets.fetch_neurovault'
+
+
+def fetch_neurovault(max_images=np.inf,
+                     query_server=True,
+                     fetch_terms=False,
+                     exclude_unpublished=False,
+                     exclude_known_bad_images=True,
+                     collection_ids=(),
+                     image_ids=(), image_type=None, map_types=(),
+                     collection_filters=(), image_filters=(),
+                     data_dir=None, url="http://neurovault.org/api",
+                     resume=True, overwrite=False, verbose=2):
+
+    return NeuroVaultDataset(data_dir=data_dir).fetch(
+        max_images=max_images, query_server=query_server,
+        fetch_terms=fetch_terms, exclude_unpublished=exclude_unpublished,
+        exclude_known_bad_images=exclude_known_bad_images,
+        collection_ids=collection_ids, image_ids=image_ids,
+        image_type=image_type, map_types=map_types,
+        collection_filters=collection_filters, image_filters=image_filters,
+        url=url, resume=resume, overwrite=overwrite, verbose=verbose)

--- a/nidata/task/neurovault/tests.py
+++ b/nidata/task/neurovault/tests.py
@@ -1,0 +1,12 @@
+from unittest import TestCase
+
+from nidata.task import NeuroVaultDataset
+from nidata.core._utils.testing import DownloadTestMixin, InstallTestMixin
+
+
+class NeuroVaultDownloadTest(DownloadTestMixin, TestCase):
+    dataset_class = NeuroVaultDataset
+
+
+class NeuroVaultInstallTest(InstallTestMixin, TestCase):
+    dataset_class = NeuroVaultDataset


### PR DESCRIPTION
To add the NeuroVault fetcher, we needed to pass more complex `pip install` strings (e.g. `git+https://github.com/INCF/openfmri2bids`) to `pip` within the python code. However, we also need the intended module name, to check whether installation is necessary.

This code extends the module installation system by allowing lists or dicts. NOTE: when using dicts, use `collections.OrderedDict`, as dependencies must be ordered!

This code also checks the `nilearn` package for dataset descriptions when the fetcher is derived from nilearn.
