### PR TITLE
ENH: add PING dataset.

### DIFF
--- a/nidata/anatomical/PING/__init__.py
+++ b/nidata/anatomical/PING/__init__.py
@@ -1,0 +1,41 @@
+# *- encoding: utf-8 -*-
+# Author: Ofer Groweiss
+# License: simplified BSD
+
+import os
+from collections import OrderedDict
+
+from ...core.datasets import HttpDataset
+
+
+class AuthenticatedHttpDataset(HttpDataset):
+    USERNAME_ENV_VAR = None
+    PASSWD_ENV_VAR = None
+
+    def __init__(self, data_dir=None, username=None, passwd=None):
+        if username is None and not os.environ.get(self.USERNAME_ENV_VAR):
+            raise ValueError("username/passwd must be passed in, or %s/%s "
+                             "environment variables must be set." % (
+                                 self.USERNAME_ENV_VAR, self.PASSWD_ENV_VAR))
+        self.username = username
+        self.passwd = passwd
+        super(AuthenticatedHttpDataset, self).__init__(data_dir=data_dir)
+
+
+class PINGDataset(AuthenticatedHttpDataset):
+    """
+    TODO: PING docstring.
+    """
+    dependencies = OrderedDict(
+        [(mod, mod) for mod in HttpDataset.dependencies],
+        ping='git+https://github.com/guruucsd/PING')
+    USERNAME_ENV_VAR = 'PING_USERNAME'
+    PASSWD_ENV_VAR = 'PING_PASSWD'
+
+    def fetch(self, n_subjects=1,
+              url=None, resume=True, force=False, verbose=1):
+        if not hasattr(self, 'dataset'):
+            from ping.ping.data import PINGData
+            self.dataset = PINGData(username=self.username, passwd=self.passwd,
+                                    data_dir=self.data_dir)
+        return self.dataset.data_dict

--- a/nidata/anatomical/PING/tests.py
+++ b/nidata/anatomical/PING/tests.py
@@ -1,0 +1,32 @@
+import os
+
+import unittest
+from nose.tools import assert_raises
+from unittest import TestCase
+
+from nidata.anatomical import PINGDataset
+from nidata.core._utils.testing import (DownloadTestMixin, InstallTestMixin)
+
+
+@unittest.skipIf(os.environ.get('NIDATA_PING_USERNAME') is None,
+                 "Authentication required.")
+class PINGDownloadTest(DownloadTestMixin, TestCase):
+    dataset_class = PINGDataset
+
+
+class PINGFailDownloadTest(unittest.TestCase):
+    @unittest.skipIf(os.environ.get('NIDATA_PING_USERNAME') is not None,
+                     "Authentication required.")
+    def test_error(self):
+        assert_raises(ValueError, PINGDataset)
+
+
+class PINGDatasetWithDummyCredentials(PINGDataset):
+    # For testing http dependency installation
+    def __init__(self):
+        super(PINGDatasetWithDummyCredentials, self).__init__(
+            username='dummy', passwd='dummy')
+
+
+class PINGInstallTest(InstallTestMixin, TestCase):
+    dataset_class = PINGDatasetWithDummyCredentials

--- a/nidata/anatomical/__init__.py
+++ b/nidata/anatomical/__init__.py
@@ -1,7 +1,4 @@
-"""
-Datasets with structural MRI and Voxel-based morphometry.
-"""
+from .oasis_vbm import OasisVbmDataset
+from .PING import PINGDataset
 
-import os.path as _osp
-from ..core._utils import import_all_submodules as _impall
-_impall(_osp.dirname(_osp.abspath(__file__)), locals(), globals())
+__all__ = ['OasisVbmDataset', 'PINGDataset']


### PR DESCRIPTION
A thin wrapper around the `PING` project, gives basic access to the PING spreadsheet of values.

To do:
- rst file describing the project, providing links and references
- example file--perhaps to examine the claim that primary visual cortex size is related to working memory:  https://www.pubchase.com/article/25100854
